### PR TITLE
Fix typo in example on SearchResults/index.js

### DIFF
--- a/src/SearchResults/index.js
+++ b/src/SearchResults/index.js
@@ -602,7 +602,7 @@ function vanillaSortFn(order, data) {
  * @example
  * helper.on('results', function(content){
  *   //get values ordered only by name ascending using the string predicate
- *   content.getFacetValues('city', {sortBy: ['name:asc']);
+ *   content.getFacetValues('city', {sortBy: ['name:asc']});
  *   //get values  ordered only by count ascending using a function
  *   content.getFacetValues('city', {
  *     // this is equivalent to ['count:asc']


### PR DESCRIPTION
Add missing `}` in example [in SearchResults section](https://github.com/algolia/algoliasearch-helper-js/blob/789f0430bd2945f93bba04a5540355abfdb889fb/src/SearchResults/index.js#L605).